### PR TITLE
Fix matching of edit paths to original file paths on Windows

### DIFF
--- a/docs/gen_pages.py
+++ b/docs/gen_pages.py
@@ -1,7 +1,11 @@
 import mkdocs_gen_files
 
 for total in range(19, 100, 20):
-    with mkdocs_gen_files.open(f"sample/{total}-bottles.md", "w") as f:
+    filename = f"sample/{total}-bottles.md"
+
+    with mkdocs_gen_files.open(filename, "w") as f:
         for i in reversed(range(1, total + 1)):
             print(f"{i} bottles of beer on the wall, {i} bottles of beer  ", file=f)
             print(f"Take one down and pass it around, **{i-1}** bottles of beer on the wall\n", file=f)
+
+    mkdocs_gen_files.set_edit_path(filename, "gen_pages.py")

--- a/mkdocs_gen_files/editor.py
+++ b/mkdocs_gen_files/editor.py
@@ -9,10 +9,6 @@ from mkdocs.config import Config, load_config
 from mkdocs.structure.files import File, Files
 
 
-def _normpath(*path: str):
-    return os.path.normpath(os.path.join(*path)).replace(os.sep, "/")
-
-
 def file_sort_key(f: File):
     parts = pathlib.PurePath(f.src_path).parts
     return tuple(
@@ -25,7 +21,7 @@ class FilesEditor:
     """The current MkDocs [config](https://www.mkdocs.org/user-guide/plugins/#config)."""
     directory: str = None
     """The base directory for `open()` ([docs_dir](https://www.mkdocs.org/user-guide/configuration/#docs_dir))."""
-    edit_paths: Mapping[str, Optional[str]]
+    edit_paths: Mapping[str, Optional[pathlib.Path]]
 
     def open(self, name: str, mode, buffering=-1, encoding=None, *args, **kwargs) -> IO:
         """Open a file under `docs_dir` virtually.
@@ -47,7 +43,7 @@ class FilesEditor:
             dest_dir=self.config["site_dir"],
             use_directory_urls=self.config["use_directory_urls"],
         )
-        normname = _normpath(name)
+        normname = pathlib.Path(name)
 
         if new or normname not in self._files:
             os.makedirs(os.path.dirname(new_f.abs_src_path), exist_ok=True)
@@ -67,10 +63,10 @@ class FilesEditor:
 
     def set_edit_path(self, name: str, edit_name: Optional[str]) -> None:
         """Choose a file path to use for the edit URI of this file."""
-        self.edit_paths[_normpath(name)] = edit_name and str(edit_name)
+        self.edit_paths[pathlib.Path(name)] = edit_name and str(edit_name)
 
     def __init__(self, files: Files, config: Config, directory: Optional[str] = None):
-        self._files = collections.ChainMap({}, {_normpath(f.src_path): f for f in files})
+        self._files = collections.ChainMap({}, {pathlib.Path(f.src_path): f for f in files})
         self.config = config
         if directory is None:
             directory = config["docs_dir"]

--- a/mkdocs_gen_files/plugin.py
+++ b/mkdocs_gen_files/plugin.py
@@ -1,4 +1,5 @@
 import logging
+import pathlib
 import runpy
 import tempfile
 import urllib.parse
@@ -41,8 +42,9 @@ class GenFilesPlugin(BasePlugin):
         repo_url = config.get("repo_url", None)
         edit_uri = config.get("edit_uri", None)
 
-        if page.file.src_path in self._edit_paths:
-            path = self._edit_paths.pop(page.file.src_path)
+        src_path = pathlib.Path(page.file.src_path)
+        if src_path in self._edit_paths:
+            path = self._edit_paths.pop(src_path)
             if repo_url and edit_uri:
                 page.edit_url = path and urllib.parse.urljoin(
                     urllib.parse.urljoin(repo_url, edit_uri), path
@@ -53,7 +55,7 @@ class GenFilesPlugin(BasePlugin):
     def on_post_build(self, config: Config):
         self._dir.cleanup()
 
-        unused_edit_paths = {k: v for k, v in self._edit_paths.items() if v is not None}
+        unused_edit_paths = {k: str(v) for k, v in self._edit_paths.items() if v}
         if unused_edit_paths:
             msg = "mkdocs_gen_files: These set_edit_path invocations went unused (the files don't exist): %r"
             log.warning(msg, unused_edit_paths)

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import pytest
 from mkdocs.structure.files import File
 
@@ -18,3 +20,9 @@ def test_file_sort_key(use_directory_urls, names):
     ]
     sorted_names = [f.src_path.replace("\\", "/") for f in sorted(files, key=editor.file_sort_key)]
     assert sorted_names == names
+
+
+def test_edit_paths_consistency():
+    ed = editor.FilesEditor([], {"docs_dir": "."})
+    ed.set_edit_path("foo//bar", "zzz//xxx")
+    assert ed.edit_paths == {pathlib.Path("foo", "bar"): "zzz//xxx"}


### PR DESCRIPTION
Fixes #3
