### PR TITLE
Ensure urljoin behaviour is correct

### DIFF
--- a/mkdocs_gen_files/plugin.py
+++ b/mkdocs_gen_files/plugin.py
@@ -47,8 +47,8 @@ class GenFilesPlugin(BasePlugin):
             path = self._edit_paths.pop(src_path)
             if repo_url and edit_uri:
                 # Ensure urljoin behavior is correct
-                if not edit_uri.startswith(('?', '#')) and not repo_url.endswith('/'):
-                    repo_url += '/'
+                if not edit_uri.startswith(("?", "#")) and not repo_url.endswith("/"):
+                    repo_url += "/"
 
                 page.edit_url = path and urllib.parse.urljoin(
                     urllib.parse.urljoin(repo_url, edit_uri), path

--- a/mkdocs_gen_files/plugin.py
+++ b/mkdocs_gen_files/plugin.py
@@ -46,6 +46,10 @@ class GenFilesPlugin(BasePlugin):
         if src_path in self._edit_paths:
             path = self._edit_paths.pop(src_path)
             if repo_url and edit_uri:
+                # Ensure urljoin behavior is correct
+                if not edit_uri.startswith(('?', '#')) and not repo_url.endswith('/'):
+                    repo_url += '/'
+
                 page.edit_url = path and urllib.parse.urljoin(
                     urllib.parse.urljoin(repo_url, edit_uri), path
                 )


### PR DESCRIPTION
Upstream bugfix for https://github.com/mkdocstrings/mkdocstrings/pull/443/

I have attempted to write the necessary tests but the layout of the library is interfering a bit:
```py
from mkdocs_gen_files import plugin
```
```py
Traceback (most recent call last):
  File "/home/davfsa/coding/mkdocs-gen-files/tests/test_plugin.py", line 4, in <module>
    from mkdocs_gen_files import plugin
  File "<frozen importlib._bootstrap>", line 1075, in _handle_fromlist
  File "/home/davfsa/coding/mkdocs-gen-files/mkdocs_gen_files/__init__.py", line 20, in __getattr__
    return getattr(FilesEditor.current(), name)
  File "/home/davfsa/coding/mkdocs-gen-files/mkdocs_gen_files/editor.py", line 94, in current
    config = load_config("mkdocs.yml")
  File "/home/davfsa/coding/mkdocs-gen-files/.venv/lib/python3.10/site-packages/mkdocs/config/base.py", line 236, in load_config
    raise exceptions.Abort(
mkdocs.exceptions.Abort: Aborted with 3 Configuration Errors!
```

Not sure what the best way to fix this would be