### PR TITLE
Add generated_by attribute to page.file

### DIFF
--- a/mkdocs_gen_files/editor.py
+++ b/mkdocs_gen_files/editor.py
@@ -45,6 +45,7 @@ class FilesEditor:
             dest_dir=self.config["site_dir"],
             use_directory_urls=self.config["use_directory_urls"],
         )
+        new_f.generated_by = "mkdocs-gen-files"
         normname = pathlib.PurePath(name).as_posix()
 
         if new or normname not in self._files:

--- a/mkdocs_gen_files/editor.py
+++ b/mkdocs_gen_files/editor.py
@@ -45,7 +45,7 @@ class FilesEditor:
             dest_dir=self.config["site_dir"],
             use_directory_urls=self.config["use_directory_urls"],
         )
-        new_f.generated_by = "mkdocs-gen-files"
+        new_f.generated_by = "mkdocs-gen-files" # type: ignore
         normname = pathlib.PurePath(name).as_posix()
 
         if new or normname not in self._files:

--- a/mkdocs_gen_files/editor.py
+++ b/mkdocs_gen_files/editor.py
@@ -45,7 +45,7 @@ class FilesEditor:
             dest_dir=self.config["site_dir"],
             use_directory_urls=self.config["use_directory_urls"],
         )
-        new_f.generated_by = "mkdocs-gen-files" # type: ignore
+        new_f.generated_by = "mkdocs-gen-files"  # type: ignore
         normname = pathlib.PurePath(name).as_posix()
 
         if new or normname not in self._files:


### PR DESCRIPTION
This PR adds an attribute to generated files.

Currently, `mkdocs-gen-files` and `mkdocs-git-revision-date-localized-plugin` are incompatible. 

Using this new attribute, this PR can add support: https://github.com/timvink/mkdocs-git-revision-date-localized-plugin/pull/102

More details in https://github.com/timvink/mkdocs-git-revision-date-localized-plugin/issues/101 