### PR TITLE
Run post-build after all other plugins

### DIFF
--- a/mkdocs_gen_files/plugin.py
+++ b/mkdocs_gen_files/plugin.py
@@ -19,6 +19,11 @@ except ImportError:
 from .config_items import ListOfFiles
 from .editor import FilesEditor
 
+try:
+    from mkdocs.plugins import event_priority
+except ImportError:
+    event_priority = lambda priority: lambda f: f  # No-op fallback
+
 log = logging.getLogger(f"mkdocs.plugins.{__name__}")
 
 
@@ -57,6 +62,7 @@ class GenFilesPlugin(BasePlugin):
 
         return html
 
+    @event_priority(-100)
     def on_post_build(self, config: Config):
         self._dir.cleanup()
 


### PR DESCRIPTION
## Description

mkdocs-gen-files deletes its temporary directory during the `post_build` event, but some other plugins like [mkdocs-i18n](https://github.com/ultrabug/mkdocs-static-i18n) use the files generated during this event as well, but also require them to be generated beforehand (during the `on_files` event). 

While it is still possible to place the plugin at the top of the `mkdocs` plugins list to solve the `on_files` dependency, this also results in the cleanup being run first. Fortunately, as of mkdocs 1.4, we can order the execution of events with the [`event_priority`](https://www.mkdocs.org/dev-guide/plugins/#event-priorities) decorator.

This PR proposes to decorate the `on_post_build` method so that it always executes last.