### PR TITLE
allow `.yaml` extension for mkdocs configuration file

### DIFF
--- a/mkdocs_gen_files/editor.py
+++ b/mkdocs_gen_files/editor.py
@@ -104,7 +104,7 @@ class FilesEditor:
         if cls._current:
             return cls._current
         if not cls._default:
-            config = load_config("mkdocs.yml")
+            config = load_config()
             config.plugins.run_event("config", config)
             cls._default = FilesEditor(Files([]), config)
         return cls._default


### PR DESCRIPTION
ran into a problem because i prefer non-shortened extensions (having a `mkdocs.yaml`):
```
Error: Config file 'mkdocs.yml' does not exist.
```

problem being that `mkdocs_gen_files.editor.FilesEditor.current` has hardcoded mkdocs configuration file to `mkdocs.yml`. 
took a look in [`mkdocs.config.base.load_config`](https://github.com/mkdocs/mkdocs/blob/4c7404485f988f409ccaf42fefe705222ff5965a/mkdocs/config/base.py#L360), this method uses [`_open_config_file`](https://github.com/mkdocs/mkdocs/blob/4c7404485f988f409ccaf42fefe705222ff5965a/mkdocs/config/base.py#L301) context manager, that has support for trying with both `yml` and `yaml`.

so the fix is to not specify a configuration file.